### PR TITLE
Adding Term to Types

### DIFF
--- a/src/Ideas/Encoding/DecoderXML.hs
+++ b/src/Ideas/Encoding/DecoderXML.hs
@@ -58,6 +58,7 @@ xmlDecoder tp =
             Context     -> decodeContext
             Rule        -> decodeRule
             Environment -> decodeArgEnvironment
+            Term        -> decoderFor (fromXML >=> fromOMOBJ)
             Location    -> decodeLocation
             StratCfg    -> decodeConfiguration
             QCGen       -> getQCGen
@@ -105,7 +106,7 @@ decodePaths = do
 decodeContext :: XMLDecoder a (Context a)
 decodeContext = do
    ex   <- getExercise
-   expr <- decodeTerm
+   expr <- decodeExpression
    env  <- decodeEnvironment
    let ctx    = setEnvironment env (inContext ex expr)
        locRef = makeRef "location"
@@ -116,8 +117,8 @@ decodeContext = do
       Nothing ->
          return ctx
 
-decodeTerm :: XMLDecoder a a
-decodeTerm = withOpenMath f
+decodeExpression :: XMLDecoder a a
+decodeExpression = withOpenMath f
  where
    f True  = decodeOMOBJ
    f False = decodeChild "expr" $ do

--- a/src/Ideas/Encoding/EncoderHTML.hs
+++ b/src/Ideas/Encoding/EncoderHTML.hs
@@ -103,6 +103,7 @@ encodeConst lm dr = encoderFor $ \tv@(val ::: tp) ->
       State       -> exerciseHeader lm <> (encodeState lm dr // val)
       Location    -> text val
       Environment -> text val
+      Term        -> text val
       Context     -> encodeContext // val
       String      -> string val
       Result      -> exerciseHeader lm <> encodeResult lm val

--- a/src/Ideas/Encoding/EncoderJSON.hs
+++ b/src/Ideas/Encoding/EncoderJSON.hs
@@ -76,6 +76,7 @@ jsonEncodeConst = encoderFor $ \(val ::: tp) ->
       Context      -> encodeContext // val
       Location     -> pure (toJSON (show val))
       Environment  -> encodeEnvironment // val
+      Term         -> pure (termToJSON val)
       Text         -> pure (toJSON (show val))
       Int          -> pure (toJSON val)
       Bool         -> pure (toJSON val)

--- a/src/Ideas/Service/Types.hs
+++ b/src/Ideas/Service/Types.hs
@@ -20,7 +20,7 @@ module Ideas.Service.Types
    , Equal(..), ShowF(..), equalM
      -- * Constructing types
    , tEnvironment, tLocation, tRule, tUnit, tTuple3, tTuple4, tTuple5, tPair
-   , tStrategy, tTree, tState, tBool, tMaybe, tString, tList
+   , tTerm, tStrategy, tTree, tState, tBool, tMaybe, tString, tList
    , tId, tService, tSomeExercise, tText, tDifficulty, tUserId ,tContext
    , tDerivation, tError, (.->), tIO, tExercise, tTestSuiteResult, tQCGen
    , tScript, tExamples, tStrategyCfg, tInt
@@ -97,6 +97,7 @@ instance Equal (Const a) where
    equal Script      Script      = Just id
    equal StratCfg    StratCfg    = Just id
    equal Environment Environment = Just id
+   equal Term        Term        = Just id
    equal SomeExercise SomeExercise = Just id
    equal Text        Text        = Just id
    equal QCGen       QCGen       = Just id
@@ -147,6 +148,7 @@ data Const a t where
    Script       :: Const a Script
    StratCfg     :: Const a StrategyCfg
    Environment  :: Const a Environment
+   Term         :: Const a Term
    Text         :: Const a Text
    QCGen        :: Const a QCGen
    Result       :: Const a TestSuite.Result
@@ -205,6 +207,7 @@ instance Show (TypedValue (Const a)) where
          Script           -> show val
          StratCfg         -> show val
          Environment      -> show val
+         Term             -> show val
          Text             -> show val
          QCGen            -> show val
          Result           -> show val
@@ -227,6 +230,7 @@ instance ShowF (Const a) where
    showF Script       = "Script"
    showF StratCfg     = "StrategyConfiguration"
    showF Environment  = "Environment"
+   showF Term         = "Term"
    showF Text         = "TextMessage"
    showF QCGen        = "QCGen"
    showF Result       = "TestSuiteResult"
@@ -328,6 +332,9 @@ tTuple5 t1 t2 t3 t4 t5 = Iso (f <-> g) (Pair t1 (Pair t2 (Pair t3 (Pair t4 t5)))
 
 tEnvironment :: Type a Environment
 tEnvironment = Const Environment
+
+tTerm :: Type a Term
+tTerm = Const Term
 
 tDifficulty :: Type a Difficulty
 tDifficulty = Tag "Difficulty" (Iso (f <-> show) tString)


### PR DESCRIPTION
I'd like to add `Term` to the service type system (`Ideas.Service.Types`).
### Why?

Because the Communicate team would like to implement services whose type is not known during construction (more precisely: during `DomainReasoner` construction). `Term` also supports at least one primitive type, namely floating-point numbers (`TFloat`).
### How?

A `Term` is encoded
- for the JSON mode: using the recently implemented JSON term encoding.
- for the OpenMath (XML) mode: using the existing OpenMath term encoding.
- for the HTML mode: simply using `show`.
### Notes
- It might be useful to export `objectSymbol` and friends from `Ideas.Encoding.Encoder`, but they're not necessary to create terms, as they can be recreated at any time.
- I noticed that various `Const` types are not supported by the XML _decoder_: `Bool`, `String` and `Int`, for example.
- I renamed some functions containing the word `Term` to contain `Expression` instead for consistency. `encodeState`, for example, yields a `State a`; `encodeTerm` should then yield a `Term`, which it didn't. None of these functions is exported, so this is not an API change.
