### PR TITLE
Recognizing exercise IDs with underscores in ModeJSON

### DIFF
--- a/src/Ideas/Encoding/ModeJSON.hs
+++ b/src/Ideas/Encoding/ModeJSON.hs
@@ -51,7 +51,7 @@ extractExerciseId json =
       Array (hd:_) -> extractExerciseId hd
       _ -> fail "no code"
  where
-   p c = not (isAlphaNum c || isSpace c || c `elem` ".-")
+   p c = not (isAlphaNum c || isSpace c || c `elem` ".-_")
 
 addVersion :: String -> JSON -> JSON
 addVersion str json =


### PR DESCRIPTION
The [documentation of `Ideas.Common.Id`](https://github.com/ideas-edu/ideas/blob/ideas-1.5/src/Ideas/Common/Id.hs) states that

> Valid symbols for identifiers are the alpha-numerical characters, together with `-` and `_`.

Currently, `Ideas.Encoding.ModeJSON.extractExerciseId` skips over strings that contain underscores. This changes that, so that (as far as I can tell) the implication "is a valid ID according to the documentation → is recognized by `extractExerciseId`" holds. (The converse does not, because of the `isSpace` condition, but I would be very wary of changing that: any recognised string is converted to an `Id` using `newId`, which drops spaces, and there are probably users who depend on this behaviour.)
