### PR TITLE
Processing type Unit (value Null) in EncoderJSON.jsonTuple

### DIFF
--- a/src/Ideas/Encoding/EncoderJSON.hs
+++ b/src/Ideas/Encoding/EncoderJSON.hs
@@ -204,11 +204,12 @@ encodeTree (Node r ts) =
 
 jsonTuple :: [JSON] -> JSON
 jsonTuple xs =
-   case mapM f xs of
+   case catMaybes <$> mapM f xs of
       Just ys | distinct (map fst ys) -> Object ys
       _ -> Array xs
  where
-   f (Object [p]) = Just p
+   f (Object [p]) = Just (Just p)
+   f Null = Just Nothing
    f _ = Nothing
 
 ruleShortInfo :: Rule a -> JSON


### PR DESCRIPTION
Consider the following type and type description (`Ideas.Service.Types.TypeRep`):

``` haskell
type MyType = (String, (Maybe String, String))

tMyType :: Type a MyType
tMyType = tPair (Tag "a" tString) (tPair (tMaybe (Tag "b" tString)) (Tag "c" tString))
```

(Note that `tMaybe` is implemented in terms of the type `Unit`.)

The value `("one", (Just "two", "three"))` is encoded as the following JSON object, as expected:

``` json
{ "a": "one"
, "b": "two"
, "c": "three"
}
```

The value `("one", (Nothing, "three"))` turns into completely different JSON:

``` json
[ {"a": "one"}
, null
, {"c": "three"}
]
```

Each tagged item becomes a separate JSON object, making it impractical to use the tags for lookups. This pull request changes the output to the more intuitive, and useful, variant

``` json
{ "a": "one"
, "c": "three"
}
```

**Why not filter out `Unit`s in `tupleList` instead?** That'd be too early: it's `jsonTuple` that decides whether a list of pairs gets turned into a JSON array or a JSON object. Removing the `Unit`s in `tupleList` would also drop them from a potential JSON array to be output, which definitely breaks applications (as array lookups are purely positional).

**Does this break existing applications?** It seems very unlikely that someone is currently using the separate-object output.

**Can `EncoderJSON` be changed without a corresponding change in `DecoderJSON`**? Yes, because currently, `DecoderJSON` does not support decoding JSON objects as lists of pairs _at all_ - it simply expects an array, processes pairs sequentially, and throws away tags.
