### PR TITLE
Exposing Ideas.Encoding.Options

### DIFF
--- a/ideas.cabal
+++ b/ideas.cabal
@@ -124,6 +124,7 @@ Library
     Ideas.Encoding.ModeJSON
     Ideas.Encoding.ModeXML
     Ideas.Encoding.OpenMathSupport
+    Ideas.Encoding.Options
     Ideas.Encoding.RulePresenter
     Ideas.Encoding.RulesInfo
     Ideas.Encoding.StrategyInfo


### PR DESCRIPTION
The newly created (renamed) module `Ideas.Encoding.Options` needs to be exposed, else client applications cannot set any options, including the new `baseUrl` that fixes issue #10.