### PR TITLE
Hid Test.QuickCheck.function that introduced ambiguity in QuickCheck-2.10

### DIFF
--- a/src/Ideas/Common/Rewriting/Term.hs
+++ b/src/Ideas/Common/Rewriting/Term.hs
@@ -39,7 +39,7 @@ import Data.Maybe
 import Ideas.Common.Id
 import Ideas.Common.View
 import Ideas.Utils.Prelude (ShowString(..))
-import Ideas.Utils.QuickCheck
+import Ideas.Utils.QuickCheck hiding (function)
 import Ideas.Utils.Uniplate
 import qualified Data.IntSet as IS
 import qualified Data.Map as M


### PR DESCRIPTION
I hid Test.QuickCheck.function in the import statement, because it caused ambiguity.
This fixes building ideas without an additional constraint on the QuickCheck version (< 2.10), which was currently missing.

For consistency I took the same action as originally taken in [another similar case of ambiguity with QuickCheck](https://github.com/ideas-edu/ideas/blob/master/src/Ideas/Utils/TestSuite.hs#L50).