### PR TITLE
Set up (Travis) testing with GHC 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ matrix:
   - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.10.3"
     addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.0.2"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.

--- a/ideas.cabal
+++ b/ideas.cabal
@@ -28,7 +28,7 @@ stability:              provisional
 extra-source-files:     NOTICE.txt, CHANGELOG.txt
 build-type:             Simple
 cabal-version:          >= 1.8.0.2
-tested-with:            GHC == 7.10.3
+tested-with:            GHC == 7.10.3, GHC == 8.0.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
As we discussed during the Hackathon, it would be nice to start testing with GHC 8.0, as it is likely to become the GHC version for Ubuntu 18.04 LTS.