### PR TITLE
Decode Unicode in XML requests earlier.

### DIFF
--- a/src/Ideas/Main/Default.hs
+++ b/src/Ideas/Main/Default.hs
@@ -122,7 +122,7 @@ defaultCommandLine options dr cmdLineOptions = do
             processDatabase dr database
          InputFile file ->
             withBinaryFile file ReadMode $ \h -> do
-               input  <- hGetContents h
+               input  <- hGetContents h >>= decoding
                (req, txt, _) <- process options dr input
                putStrLn txt
                when (PrintLog `elem` cmdLineOptions) $ do

--- a/src/Ideas/Main/Default.hs
+++ b/src/Ideas/Main/Default.hs
@@ -44,6 +44,7 @@ import qualified Ideas.Encoding.Logging as Log
 import qualified Ideas.Main.CGI as CGI
 import qualified Ideas.Main.CmdLineOptions as Options
 import qualified Network.Wai as WAI
+import Ideas.Text.XML.Unicode (decoding)
 
 defaultMain :: DomainReasoner -> IO ()
 defaultMain = defaultMainWith mempty
@@ -65,7 +66,7 @@ defaultCGI options dr = CGI.run $ \req respond -> do
    -- query environment
    let script = fromMaybe "" (findHeader "CGI-Script-Name" req) -- get name of binary
        addr   = fromMaybe "" (findHeader "REMOTE_ADDR" req)     -- the IP address of the remote host
-   input   <- inputOrDefault req
+   input   <- inputOrDefault req >>= decoding
    -- process request
    (preq, txt, ctp) <-
       process (optionCgiBin script options) dr input

--- a/src/Ideas/Text/JSON.hs
+++ b/src/Ideas/Text/JSON.hs
@@ -163,7 +163,7 @@ parseJSON = parseSimple json
       , Boolean True  <$ P.reserved lexer "true"
       , Boolean False <$ P.reserved lexer "false"
       , Number . either I D <$> naturalOrFloat -- redefined in Ideas.Text.Parsing
-      , String . fromMaybe [] . UTF8.decodeM <$> P.stringLiteral lexer
+      , String <$> P.stringLiteral lexer
       , Array  <$> P.brackets lexer (sepBy json (P.comma lexer))
       , Object <$> P.braces lexer (sepBy keyValue (P.comma lexer))
       ]

--- a/src/Ideas/Text/XML.hs
+++ b/src/Ideas/Text/XML.hs
@@ -75,8 +75,7 @@ data Attribute = Name := String
 -- Parsing XML
 
 parseXML :: String -> Either String XML
-parseXML xs = do
-   input <- decoding xs
+parseXML input = do
    doc   <- parseSimple document input
    return (fromXMLDoc doc)
 


### PR DESCRIPTION
Previously, Unicode in input requests was only decoded when parsing the
XML. However, requests are already processed before that.

Unicode is now decoded at an earlier point, so that requests are saved
to the database with proper encoding. This means that the behaviour of
`parseXML` changes: passing improperly encoded Unicode to it will now
result in gibberish.

Relates to the ticket http://ideastest.science.uu.nl/trac/ticket/240